### PR TITLE
Fix #45 response : 에러 응답에 stackTrace 등이 나오는 문제 해결

### DIFF
--- a/src/main/java/com/coderder/colorMeeting/config/jwt/JwtUtil.java
+++ b/src/main/java/com/coderder/colorMeeting/config/jwt/JwtUtil.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Component;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-//@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtUtil {
@@ -23,6 +22,7 @@ public class JwtUtil {
 
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
+        response.setStatus(401);
         response.getWriter().write(httpResponse);
 
     }

--- a/src/main/java/com/coderder/colorMeeting/config/jwt/JwtUtil.java
+++ b/src/main/java/com/coderder/colorMeeting/config/jwt/JwtUtil.java
@@ -5,16 +5,22 @@ import com.coderder.colorMeeting.exception.ErrorCode;
 import com.coderder.colorMeeting.exception.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+//@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtUtil {
     private final ObjectMapper objectMapper;
+
+    private final Logger logger = LoggerFactory.getLogger("JwtUtil 의 로그");
 
     // 예외 응답
     public void exceptionResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
@@ -22,8 +28,23 @@ public class JwtUtil {
         response.setCharacterEncoding("UTF-8");
 //        ResponseDto<?> responseDto = ResponseDto.fail(errorCode);
         ErrorResponse errorResponse = new ErrorResponse(errorCode);
+//        String httpResponse = objectMapper.writeValueAsString(errorResponse);
         String httpResponse = objectMapper.writeValueAsString(errorResponse);
+
+        logger.debug("response에 Write 전");
+        logger.debug(httpResponse);
+        logger.debug(httpResponse.toString());
+
+//        log.debug("어노테이션, response에 Write 전");
+//        log.debug(httpResponse);
+
         response.getWriter().write(httpResponse);
+
+        logger.debug("response에 Write 후");
+        logger.debug(response.toString());
+
+//        log.debug("어노테이션, response에 Write 후");
+//        log.debug(response.toString());
     }
 
 }

--- a/src/main/java/com/coderder/colorMeeting/config/jwt/JwtUtil.java
+++ b/src/main/java/com/coderder/colorMeeting/config/jwt/JwtUtil.java
@@ -1,14 +1,9 @@
 package com.coderder.colorMeeting.config.jwt;
 
-import com.coderder.colorMeeting.dto.response.ResponseDto;
 import com.coderder.colorMeeting.exception.ErrorCode;
 import com.coderder.colorMeeting.exception.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletResponse;
@@ -20,31 +15,16 @@ import java.io.IOException;
 public class JwtUtil {
     private final ObjectMapper objectMapper;
 
-    private final Logger logger = LoggerFactory.getLogger("JwtUtil 의 로그");
-
     // 예외 응답
     public void exceptionResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-//        ResponseDto<?> responseDto = ResponseDto.fail(errorCode);
+
         ErrorResponse errorResponse = new ErrorResponse(errorCode);
-//        String httpResponse = objectMapper.writeValueAsString(errorResponse);
         String httpResponse = objectMapper.writeValueAsString(errorResponse);
 
-        logger.debug("response에 Write 전");
-        logger.debug(httpResponse);
-        logger.debug(httpResponse.toString());
-
-//        log.debug("어노테이션, response에 Write 전");
-//        log.debug(httpResponse);
-
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
         response.getWriter().write(httpResponse);
 
-        logger.debug("response에 Write 후");
-        logger.debug(response.toString());
-
-//        log.debug("어노테이션, response에 Write 후");
-//        log.debug(response.toString());
     }
 
 }

--- a/src/main/java/com/coderder/colorMeeting/exception/ErrorCode.java
+++ b/src/main/java/com/coderder/colorMeeting/exception/ErrorCode.java
@@ -38,7 +38,18 @@ public enum ErrorCode {
     NOT_AUTHORIZED("NOT_AUTHORIZED", "권한이 없습니다."),
 
     // 회원가입 로직 : 중복 아이디
-    USERNAME_ALREADY_EXISTS("USERNAME_ALREADY_EXISTS", "이미 존재하는 유저입니다");
+    USERNAME_ALREADY_EXISTS("USERNAME_ALREADY_EXISTS", "이미 존재하는 유저입니다"),
+
+    // Spring 기본 오류
+    INVALID_INPUT_VALUE("INVALID_INPUT_VALUE", "유효하지 않은 입력값입니다."),
+    TYPE_MISMATCH("TYPE_MISMATCH", "입력된 enum값이 유효하지 않습니다."),
+    METHOD_NOT_ALLOWED("METHOD_NOT_ALLOWED", "유효하지 않은 HTTP method입니다."),
+    HANDLE_ACCESS_DENIED("HANDLE_ACCESS_DENIED", "Authentication 객체가 필요한 권한을 보유하지 않았습니다."),
+    INTERNAL_SERVER_ERROR("INTERNAL_SERVER_ERROR", "Server Error"),
+
+    // 잘못된 URL 오류
+    URL_NOT_FOUND("URL_NOT_FOUND", "유효하지 않은 URL입니다.");
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/coderder/colorMeeting/exception/ErrorResponse.java
+++ b/src/main/java/com/coderder/colorMeeting/exception/ErrorResponse.java
@@ -1,13 +1,11 @@
 package com.coderder.colorMeeting.exception;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder
 @AllArgsConstructor
-public class ErrorResponse extends RuntimeException {
+public class ErrorResponse {
     private String code;
     private String message;
 

--- a/src/main/java/com/coderder/colorMeeting/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coderder/colorMeeting/exception/GlobalExceptionHandler.java
@@ -1,30 +1,133 @@
 package com.coderder.colorMeeting.exception;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
+import java.net.BindException;
+import java.nio.file.AccessDeniedException;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * Business Exception Hanlding
+     * 비즈니스 요구사항 예외 처리
+     */
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse>notFoundExceptionHandler(NotFoundException exception) {
-        return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.NOT_FOUND);
+    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+        log.error("handleNotFoundException", e);
+        return new ResponseEntity<>(new ErrorResponse(e.getErrorCode()), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> BadRequestExceptionHandler(BadRequestException exception) {
-        return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.BAD_REQUEST);
+    public ResponseEntity<ErrorResponse> handleBadRequestException(BadRequestException e) {
+        log.error("handleBadRequestException", e);
+        return new ResponseEntity<>(new ErrorResponse(e.getErrorCode()), BAD_REQUEST);
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> unAuthorizedExceptionHandler(UnAuthorizedException exception) {
-        return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.UNAUTHORIZED);
+    public ResponseEntity<ErrorResponse> handleUnAuthorizedException(UnAuthorizedException e) {
+        log.error("handleUnAuthorizedException", e);
+        return new ResponseEntity<>(new ErrorResponse(e.getErrorCode()), HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler
-    public ResponseEntity<ErrorResponse> ForbiddenExceptionHandler(ForbiddenException exception) {
-        return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.FORBIDDEN);
+    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+        log.error("handleForbiddenException", e);
+        return new ResponseEntity<>(new ErrorResponse(e.getErrorCode()), HttpStatus.FORBIDDEN);
+    }
+
+    /**
+     * Spring에서 발생하는 에러 Handling
+     * 아래는 가장 기본적이며 필수적으로 처리하는 코드라고 함
+     */
+
+    /**
+     *  javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+     *  HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
+     *  주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.error("handleMethodArgumentNotValidException", e);
+        return new ResponseEntity<>(new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE), BAD_REQUEST);
+    }
+
+    /**
+     * @ModelAttribut 으로 binding error 발생시 BindException 발생한다.
+     * ref https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
+     */
+    @ExceptionHandler(BindException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        log.error("handleBindException", e);
+        return new ResponseEntity<>(new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE), BAD_REQUEST);
+
+    }
+
+    /**
+     * enum type 일치하지 않아 binding 못할 경우 발생
+     * 주로 @RequestParam enum으로 binding 못했을 경우 발생
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        log.error("handleMethodArgumentTypeMismatchException", e);
+        return new ResponseEntity<>(new ErrorResponse(ErrorCode.TYPE_MISMATCH), BAD_REQUEST);
+
+    }
+
+    /**
+     * 지원하지 않은 HTTP method 호출 할 경우 발생
+     */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        log.error("handleHttpRequestMethodNotSupportedException", e);
+        return new ResponseEntity<>(new ErrorResponse(ErrorCode.METHOD_NOT_ALLOWED), BAD_REQUEST);
+
+    }
+
+    /**
+     * Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합
+     */
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("handleAccessDeniedException", e);
+        return new ResponseEntity<>(new ErrorResponse(ErrorCode.METHOD_NOT_ALLOWED), FORBIDDEN);
+
+    }
+
+//    @ExceptionHandler(BusinessException.class)
+//    protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+//        log.error("handleEntityNotFoundException", e);
+//        final ErrorCode errorCode = e.getErrorCode();
+//        final ErrorResponse response = ErrorResponse.of(errorCode);
+//        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+//    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("handleEntityNotFoundException", e);
+        return new ResponseEntity<>(new ErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR), INTERNAL_SERVER_ERROR);
+    }
+
+    /* 잘못된 URL 요청시 - 404 Not Found
+     * 500 메세지는 Internal Server Error이므로 @ExceptionHandler를 이용해서 처리가 가능하지만,
+     * 404 메세지는 문법 오류가 아니고 잘못된 URL을 호출할 때 보이므로 다르게 처리해주어야 함.
+     */
+    @ExceptionHandler(NoHandlerFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ResponseEntity<ErrorResponse> handle404(NoHandlerFoundException e){
+        log.error("NoHandlerFoundException", e);
+        return new ResponseEntity<>(new ErrorResponse(ErrorCode.URL_NOT_FOUND), NOT_FOUND);
     }
 }

--- a/src/main/java/com/coderder/colorMeeting/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/coderder/colorMeeting/exception/GlobalExceptionHandler.java
@@ -9,22 +9,22 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler
-    public ResponseEntity<?>notFoundExceptionHandler(NotFoundException exception) {
+    public ResponseEntity<ErrorResponse>notFoundExceptionHandler(NotFoundException exception) {
         return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.NOT_FOUND);
     }
 
     @ExceptionHandler
-    public ResponseEntity<?> BadRequestExceptionHandler(BadRequestException exception) {
+    public ResponseEntity<ErrorResponse> BadRequestExceptionHandler(BadRequestException exception) {
         return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler
-    public ResponseEntity<?> unAuthorizedExceptionHandler(UnAuthorizedException exception) {
+    public ResponseEntity<ErrorResponse> unAuthorizedExceptionHandler(UnAuthorizedException exception) {
         return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.UNAUTHORIZED);
     }
 
     @ExceptionHandler
-    public ResponseEntity<?> ForbiddenExceptionHandler(ForbiddenException exception) {
+    public ResponseEntity<ErrorResponse> ForbiddenExceptionHandler(ForbiddenException exception) {
         return new ResponseEntity<>(new ErrorResponse(exception.getErrorCode()), HttpStatus.FORBIDDEN);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,6 @@ server.servlet.context-path=/
 server.servlet.encoding.charset=UTF-8
 server.servlet.encoding.enabled=true
 server.servlet.encoding.force=true
+
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.web.resources.add-mappings=false


### PR DESCRIPTION
### 원인
`ErrorResponse`가 `JwtUtil`을 거치며 String으로 바뀌며 무언가 추가로 붙는 줄 알았는데, 디버깅해보니 이미 `ErrorResponse`가 생성될 때부터 property로 stackTrace를 비롯한 이것 저것 생기더군요. 엥 이게 뭐지? 해서 `ErrorResponse`가보니.. `ErrorResponse` 클래스가 `RuntimeException`을 상속받게 하는, 어이없는 실수 때문이었습니다.

(작성자가 코드 쓸 때 졸았나 봅니다. 이것도 모르고 계속 Spring Security 필터만 뜯어보고 있었으니 해결될 턱이.. 없었네요.😭)

### 변경 전
```java
@Getter
@Builder
@AllArgsConstructor
public class ErrorResponse extends RuntimeException {
    private String code;
    private String message;

    public ErrorResponse(ErrorCode errorCode) {
        this.code = errorCode.getCode();
        this.message = errorCode.getMessage();
    }
}
```

### 변경 후
```java
@Getter
@Builder
@AllArgsConstructor
public class ErrorResponse {
    private String code;
    private String message;

    public ErrorResponse(ErrorCode errorCode) {
        this.code = errorCode.getCode();
        this.message = errorCode.getMessage();
    }
}
```